### PR TITLE
Fixing a bug: Question Entity creation failure, Question.suspended default value missed

### DIFF
--- a/guru.py
+++ b/guru.py
@@ -305,7 +305,7 @@ class XmppHandler(xmpp_handlers.CommandHandler):
             message.reply(WAIT_MSG)
         else:
             # Asking a question
-            asked_question = Question(question=message.arg, asker=im_from)
+            asked_question = Question(question=message.arg, asker=im_from, suspended=False)
             asked_question.put()
 
             currently_answering = Question.get_answering(im_from)


### PR DESCRIPTION
Fixing a bug: Question Entity creation failure, Question.suspended default value missed in guru.py, line 309, tellme_command

```
Entity has uninitialized properties: suspended
Traceback (most recent call last):
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.3/webapp2.py", line 1511, in __call__
    rv = self.handle_exception(request, response, e)
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.3/webapp2.py", line 1505, in __call__
    rv = self.router.dispatch(request, response)
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.3/webapp2.py", line 1253, in default_dispatcher
    return route.handler_adapter(request, response)
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.3/webapp2.py", line 1077, in __call__
    return handler.dispatch()
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.3/webapp2.py", line 547, in dispatch
    return self.handle_exception(e, self.app.debug)
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/webapp/xmpp_handlers.py", line 62, in handle_exception
    super(BaseHandler, self).handle_exception(exception, debug_mode)
  File "/base/data/home/runtimes/python27/python27_lib/versions/third_party/webapp2-2.3/webapp2.py", line 545, in dispatch
    return method(*args, **kwargs)
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/webapp/xmpp_handlers.py", line 72, in post
    self.message_received(self.xmpp_message)
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/webapp/xmpp_handlers.py", line 117, in message_received
    handler(message)
  File "/base/data/home/apps/s~xmpp-link/1.372269623326743716/guru.py", line 309, in tellme_command
    asked_question.put()
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/ndb/model.py", line 3232, in _put
    return self._put_async(**ctx_options).get_result()
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/ndb/tasklets.py", line 325, in get_result
    self.check_success()
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/ndb/tasklets.py", line 368, in _help_tasklet_along
    value = gen.throw(exc.__class__, exc, tb)
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/ndb/context.py", line 748, in put
    key = yield self._put_batcher.add(entity, options)
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/ndb/tasklets.py", line 371, in _help_tasklet_along
    value = gen.send(val)
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/ndb/context.py", line 280, in _put_tasklet
    keys = yield self._conn.async_put(options, datastore_entities)
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/datastore/datastore_rpc.py", line 1648, in async_put
    pbs = [self.__adapter.entity_to_pb(entity) for entity in entities]
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/ndb/model.py", line 570, in entity_to_pb
    pb = ent._to_pb()
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/ndb/model.py", line 2936, in _to_pb
    self._check_initialized()
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/ext/ndb/model.py", line 2812, in _check_initialized
    'Entity has uninitialized properties: %s' % ', '.join(baddies))
BadValueError: Entity has uninitialized properties: suspended

```
